### PR TITLE
Fix linting issues in boilerplate service

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ run:
   concurrency: 4
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
+  timeout: 10m
 linters-settings:
   govet:
     check-shadowing: true
@@ -81,11 +81,23 @@ issues:
         - errcheck
         - dupl
         - gosec
+    # Allow log.Fatal in main.go (log.go library continues after calling this, unlike std library log.Fatal)
+    - path: main.go
+      text: "unreachable-code"
+      linters:
+        - revive
+      source: "log.Fatal"
+    # Allow dot import in test files for goconvey
+    - path: _test.go
+      text: "dot-imports"
+      linters:
+        - revive
+      source: "github.com/smartystreets/goconvey/convey"
   new: false
 
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.55.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.56.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,6 +44,12 @@ linters-settings:
   funlen:
   # lines: 100
   # statements: 100
+  revive:
+    rules:
+      # disabled as parameter names are useful for context even when unused, especially in interface implementations
+      - name: unused-parameter
+        severity: warning
+        disabled: true
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -24,7 +24,7 @@ func TestSetup(t *testing.T) {
 }
 
 func hasRoute(m *http.ServeMux, path, method string) bool {
-	req := httptest.NewRequest(method, path, nil)
+	req := httptest.NewRequest(method, path, http.NoBody)
 
 	_, pat := m.Handler(req)
 	return pat != ""

--- a/api/hello_test.go
+++ b/api/hello_test.go
@@ -17,7 +17,7 @@ func TestHelloHandler(t *testing.T) {
 		helloHandler := HelloHandler(ctx)
 
 		Convey("when a good response is returned", func() {
-			req := httptest.NewRequest("GET", "http://localhost:8080/hello", nil)
+			req := httptest.NewRequest("GET", "http://localhost:8080/hello", http.NoBody)
 			resp := httptest.NewRecorder()
 
 			helloHandler.ServeHTTP(resp, req)

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golangci/golangci-lint
-    tag: v1.55
+    tag: v1.56
 
 inputs:
   - name: dp-data-api


### PR DESCRIPTION
### What

- Upgrade golangci-lint for go v1.22
- Fix linting issues
- Disable over-zealous linter

### How to review

Ensure tests pass

### Who can review

Anyone